### PR TITLE
Split Signing the JWT into its own function

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 import yargs from 'yargs';
 import {hideBin} from 'yargs/helpers';
 import clientAssertion from './lib/commands/client-assertion.js';
+import signJWT from './lib/commands/sign-jwt.js';
 import fs from 'fs';
 
 const packageJson = JSON.parse(fs.readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
@@ -20,6 +21,7 @@ const argv = yargs(hideBin(process.argv))
       describe: 'Path to the PEM encoded private key used to sign the assertion',
       type: 'string'
     })
+    .command('sign-jwt', 'Only create a signed JWT for use with the Banno back office OAuth flow')
     .strict()
     .help()
     .argv;
@@ -27,6 +29,9 @@ const argv = yargs(hideBin(process.argv))
 switch (argv._[0].toString().toLowerCase()) {
   case 'client-assertion':
     clientAssertion(argv['client-id'], argv['private-key']).catch((e) => console.error(e));
+    break;
+  case 'sign-jwt':
+    signJWT(argv['client-id'], argv['private-key']).catch((e) => console.error(e));
     break;
   default:
     break;

--- a/lib/commands/client-assertion.js
+++ b/lib/commands/client-assertion.js
@@ -4,35 +4,13 @@ import chalk from 'chalk';
 import fs from 'fs';
 import querystring from 'querystring';
 import fetch from 'node-fetch';
+import signJWT from './sign-jwt.js';
 
 export default async function clientAssertion(clientId, privateKeyPath) {
   // Obtain an access token to call banno apis
   const enterpriseOidcTokenUri = 'https://banno.com/a/oidc-provider/api/v0/token';
-  
-  const jwtPayload = {
-    jti: uuid(),
-    aud: enterpriseOidcTokenUri,
-    sub: clientId,
-    iss: clientId,
-    exp: Date.now() + 60 * 1000
-  };
 
-  process.stdout.write(`${chalk.green('Client assertion payload:')} ${JSON.stringify(jwtPayload, null, 2)}\n`);
-
-  const privateKey = await fs.promises.readFile(privateKeyPath, {encoding: 'utf8'});
-
-  const jwkKeystore = jose.JWK.createKeyStore();
-  await jwkKeystore.add(privateKey, 'pem');
-  const jwkKey = jwkKeystore.all({use: 'sig', alg: 'PS256'})[0];
-  
-  /** @type {string} */
-  const clientAssertion =
-    /** @type {*} */ (await jose.JWS.createSign({format: 'compact'}, /** @type {*} */ (jwkKey))
-        .update(JSON.stringify(jwtPayload))
-        .final());
-
-  process.stdout.write(`${chalk.green('Signed client assertion:')} ${clientAssertion}\n`);
-  process.stdout.write(chalk.grey('You can inspect the assertion at https://jwt.io/') + '\n\n');
+  clientAssertion = await signJWT(clientId, privateKeyPath)
 
   const tokenPayload = {
     client_assertion: clientAssertion,

--- a/lib/commands/client-assertion.js
+++ b/lib/commands/client-assertion.js
@@ -1,7 +1,4 @@
-import jose from 'node-jose';
-import {v4 as uuid} from 'uuid';
 import chalk from 'chalk';
-import fs from 'fs';
 import querystring from 'querystring';
 import fetch from 'node-fetch';
 import signJWT from './sign-jwt.js';

--- a/lib/commands/sign-jwt.js
+++ b/lib/commands/sign-jwt.js
@@ -8,7 +8,7 @@ import fetch from 'node-fetch';
 export default async function signJWT(clientId, privateKeyPath) {
     // Obtain an access token to call banno apis
     const enterpriseOidcTokenUri = 'https://banno.com/a/oidc-provider/api/v0/token';
-    
+
     const jwtPayload = {
         jti: uuid(),
         aud: enterpriseOidcTokenUri,
@@ -24,15 +24,15 @@ export default async function signJWT(clientId, privateKeyPath) {
     const jwkKeystore = jose.JWK.createKeyStore();
     await jwkKeystore.add(privateKey, 'pem');
     const jwkKey = jwkKeystore.all({use: 'sig', alg: 'PS256'})[0];
-    
+
     /** @type {string} */
     const clientAssertion =
         /** @type {*} */ (await jose.JWS.createSign({format: 'compact'}, /** @type {*} */ (jwkKey))
             .update(JSON.stringify(jwtPayload))
             .final());
-    
+
     process.stdout.write(`${chalk.green('Signed client JWT:')} ${clientAssertion}\n`);
     process.stdout.write(chalk.grey('\nYou can inspect the JWT at ') + chalk.underline.yellow('https://jwt.io/') + '\n\n')
-    
+
     return(clientAssertion)
 }

--- a/lib/commands/sign-jwt.js
+++ b/lib/commands/sign-jwt.js
@@ -17,7 +17,7 @@ export default async function signJWT(clientId, privateKeyPath) {
         exp: Date.now() + 60 * 1000
     };
 
-    process.stdout.write(`${chalk.green('Client assertion payload:')} ${JSON.stringify(jwtPayload, null, 2)}\n`);
+    process.stdout.write(`${chalk.green('Client JWT payload:')} ${JSON.stringify(jwtPayload, null, 2)}\n`);
 
     const privateKey = await fs.promises.readFile(privateKeyPath, {encoding: 'utf8'});
 
@@ -31,8 +31,8 @@ export default async function signJWT(clientId, privateKeyPath) {
             .update(JSON.stringify(jwtPayload))
             .final());
     
-    process.stdout.write(`${chalk.green('Signed client assertion:')} ${clientAssertion}\n`);
-    process.stdout.write(chalk.grey('\nYou can inspect the assertion at https://jwt.io/') + '\n\n')
+    process.stdout.write(`${chalk.green('Signed client JWT:')} ${clientAssertion}\n`);
+    process.stdout.write(chalk.grey('\nYou can inspect the JWT at ') + chalk.underline.yellow('https://jwt.io/') + '\n\n')
     
     return(clientAssertion)
 }

--- a/lib/commands/sign-jwt.js
+++ b/lib/commands/sign-jwt.js
@@ -1,0 +1,38 @@
+import jose from 'node-jose';
+import {v4 as uuid} from 'uuid';
+import chalk from 'chalk';
+import fs from 'fs';
+import querystring from 'querystring';
+import fetch from 'node-fetch';
+
+export default async function signJWT(clientId, privateKeyPath) {
+    // Obtain an access token to call banno apis
+    const enterpriseOidcTokenUri = 'https://banno.com/a/oidc-provider/api/v0/token';
+    
+    const jwtPayload = {
+        jti: uuid(),
+        aud: enterpriseOidcTokenUri,
+        sub: clientId,
+        iss: clientId,
+        exp: Date.now() + 60 * 1000
+    };
+
+    process.stdout.write(`${chalk.green('Client assertion payload:')} ${JSON.stringify(jwtPayload, null, 2)}\n`);
+
+    const privateKey = await fs.promises.readFile(privateKeyPath, {encoding: 'utf8'});
+
+    const jwkKeystore = jose.JWK.createKeyStore();
+    await jwkKeystore.add(privateKey, 'pem');
+    const jwkKey = jwkKeystore.all({use: 'sig', alg: 'PS256'})[0];
+    
+    /** @type {string} */
+    const clientAssertion =
+        /** @type {*} */ (await jose.JWS.createSign({format: 'compact'}, /** @type {*} */ (jwkKey))
+            .update(JSON.stringify(jwtPayload))
+            .final());
+    
+    process.stdout.write(`${chalk.green('Signed client assertion:')} ${clientAssertion}\n`);
+    process.stdout.write(chalk.grey('\nYou can inspect the assertion at https://jwt.io/') + '\n\n')
+    
+    return(clientAssertion)
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jkhy/banno-client-creds-helper",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Helper utilities to debug connecting to Banno's Platform API using client credentials",
   "main": "index.js",
   "private": false,


### PR DESCRIPTION
## Summary
The purpose of this is to help people better understand what is going on under the hood. The previous version did everything in one command:

1. Create a JWT Payload
2. Sign the JWT Payload
3. Send the Signed JWT Payload to the Token endpoint to retrieve an Access Token

This introduces a new function `signJWT` and associated command `sign-jwt` that only does:
1. Create a JWT Payload
2. Sign the JWT Payload

The existing `client-assertion` still works the same as before.

## Jira ticket
https://banno-jha.atlassian.net/browse/DX-660

## TO DO
For @ChadKillingsworth - what is the process to publish the new version to NPM?