### PR TITLE
Avoid assigning a value to the named function

### DIFF
--- a/lib/commands/client-assertion.js
+++ b/lib/commands/client-assertion.js
@@ -7,10 +7,10 @@ export default async function clientAssertion(clientId, privateKeyPath) {
   // Obtain an access token to call banno apis
   const enterpriseOidcTokenUri = 'https://banno.com/a/oidc-provider/api/v0/token';
 
-  clientAssertion = await signJWT(clientId, privateKeyPath)
+  const jwt = await signJWT(clientId, privateKeyPath)
 
   const tokenPayload = {
-    client_assertion: clientAssertion,
+    client_assertion: jwt,
     client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
     grant_type: 'client_credentials',
     scope: 'openid full'


### PR DESCRIPTION
Use a new variable instead of reassigning to the function name