### PR TITLE
chore: ensure pnpm-workspace.yaml has required security settings

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+blockExoticSubdeps: true
+minimumReleaseAge: 14160


### PR DESCRIPTION
## Summary
- Ensures `pnpm-workspace.yaml` includes `blockExoticSubdeps: true` and `minimumReleaseAge: 14160`.

## Test plan
- [ ] Verify `pnpm-workspace.yaml` contains the required fields
- [ ] Confirm no existing workspace config was removed